### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "optimist": "~0.6.1",
     "osenv": "^0.1.0",
     "provinces": "~1.8.0",
-    "request": "~2.67.0",
+    "request": "~2.74.0",
     "split": "~1.0.0",
     "stream-combiner": "^0.2.1",
     "tar": "~2.2.1",


### PR DESCRIPTION
stream-adventure currently has a 3 vulnerable dependencies, introducing 3 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDos vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/substack/stream-adventure) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `minimatch` as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)